### PR TITLE
Python 3 fixes and use bcrypt instead of cryptacular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ atlassian-ide-plugin.xml
 .DS_Store
 .eggs/
 .tox/
+env

--- a/apex/templates/forms/fieldsetform.mako
+++ b/apex/templates/forms/fieldsetform.mako
@@ -1,4 +1,4 @@
-%if form.errors.has_key('whole_form'):
+%if 'whole_form' in form.errors:
 	%for error in form.errors.get('whole_form'):
 		<p class="field_error">${error}</p>
 	%endfor

--- a/apex/templates/forms/tableform.mako
+++ b/apex/templates/forms/tableform.mako
@@ -1,4 +1,4 @@
-%if form.errors.has_key('whole_form'):
+%if 'whole_form' in form.errors:
 	%for error in form.errors.get('whole_form'):
 		<p class="field_error">${error}</p>
 	%endfor

--- a/apex/templates/forms/tableform.pt
+++ b/apex/templates/forms/tableform.pt
@@ -2,7 +2,7 @@
   metal:define-macro="main"
   xmlns:i18n="http://xml.zope.org/namespaces/i18n"
   i18n:domain="Apex">
-  <tal:if tal:condition="form.errors.has_key('whole_form')">
+  <tal:if tal:condition="'whole_form' in form.errors">
     <tal:r  tal:repeat="error form.errors.get('whole_form')">
       <p class="field_error">${error}</p>
     </tal:r>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptacular
+bcrypt>=3.0.0
 zope.sqlalchemy
 velruse >= 1.0.3
 pyramid > 1.1.2

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ from setuptools import setup
 
 py_version = sys.version_info[:2]
 
-version = '0.9.11'
+version = '0.10.0'
 
 install_requires = [
-    "cryptacular",
+    "bcrypt>=3.0.0",
     "zope.sqlalchemy",
     "velruse>=1.0.3",
     "pyramid>=1.5.1",


### PR DESCRIPTION
Hello. Any interest in merging this?

This changes the dependency from `cryptacular` to `bcrypt` because the former package seems to have some compatibility problems and isn't actively maintained. 

This also gives some Python 3 fixes in the mako templates.